### PR TITLE
define sendMidiEvent in AbstractControlSurface

### DIFF
--- a/core/AbstractControlSurface.js
+++ b/core/AbstractControlSurface.js
@@ -475,3 +475,8 @@ AbstractControlSurface.prototype.changeValue = function (control, value)
 {
     return changeValue (control, value, this.getFractionValue (), Config.maxParameterValue);
 };
+
+AbstractControlSurface.prototype.sendMidiEvent = function (status, data1, data2)
+{
+    this.noteInput.sendRawMidiEvent (status, data1, data2);
+};


### PR DESCRIPTION
Threw me off when I was trying to implement aftertouch in Maschine; yours was defined in Push.js so I was getting "not found" errors.